### PR TITLE
Specify which packages to install for OpenGL support on aarch64

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ mamba install compilers cmake pkg-config make ninja colcon-common-extensions
 # see https://docs.microsoft.com/en-us/cpp/build/vscpp-step-0-installation?view=msvc-160
 
 # only on linux, if you are having issues finding GL/OpenGL, also do:
+# (if you are on linux/arm64, change x86_64 with aarch64)
 mamba install mesa-libgl-devel-cos7-x86_64 mesa-dri-drivers-cos7-x86_64 libselinux-cos7-x86_64 libxdamage-cos7-x86_64 libxxf86vm-cos7-x86_64 libxext-cos7-x86_64 xorg-libxfixes
 
 # on Windows, install the Visual Studio command prompt via Conda:


### PR DESCRIPTION
@Nicogene and @martinaxgloria were installing ROS Humble on a aarch64 machine, and were not able to install the OpenGL packages. I tried to provide the info of which packages to install in the most minimal way possible to avoid confusing further "regular" x86_64 users, but any suggestions to improve this are welcome.

fyi @Tobias-Fischer 