### PR TITLE
Add ackermann, admittance and forward-command ros2_controllers for osx on main branch

### DIFF
--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -52,6 +52,7 @@ packages_select_by_deps:
   - foxglove_bridge
   - turtlebot3
 
+  - control_msgs
   - steering-controllers-library
   - ackermann-steering-controller
   - admittance-controller  

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -52,6 +52,11 @@ packages_select_by_deps:
   - foxglove_bridge
   - turtlebot3
 
+  - steering-controllers-library
+  - ackermann-steering-controller
+  - admittance-controller  
+  - forward-command-controller
+
   - joint-state-broadcaster
   - joint-state-publisher
   - joint-trajectory-controller

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 3
+build_number: 4
 
 mutex_package: ros2-distro-mutex 0.3 humble
 
@@ -13,7 +13,7 @@ skip_all_deps: false
 
 # If full rebuild, the build number of the existing package has
 # to match the selected build number for skipping
-full_rebuild: true
+full_rebuild: false
 
 # build_in_own_azure_stage:
 # - ros-galactic-rviz-rendering
@@ -38,19 +38,19 @@ skip_existing:
   - https://conda.anaconda.org/robostack-staging/
 
 packages_select_by_deps:
-  - ros_workspace
-  - ros_environment
-  - ros_base
-  - desktop
-  - moveit
-  - moveit_servo
-  - desktop_full
-  - navigation2
-  - rosbridge_suite
-  - vision_msgs
-  - rosbag2_storage_mcap
-  - foxglove_bridge
-  - turtlebot3
+  # - ros_workspace
+  # - ros_environment
+  # - ros_base
+  # - desktop
+  # - moveit
+  # - moveit_servo
+  # - desktop_full
+  # - navigation2
+  # - rosbridge_suite
+  # - vision_msgs
+  # - rosbag2_storage_mcap
+  # - foxglove_bridge
+  # - turtlebot3
 
   - control_msgs
   - steering-controllers-library
@@ -58,26 +58,26 @@ packages_select_by_deps:
   - admittance-controller  
   - forward-command-controller
 
-  - joint-state-broadcaster
-  - joint-state-publisher
-  - joint-trajectory-controller
-  - joint-limits
-  - xacro
-  - robot-localization
+  # - joint-state-broadcaster
+  # - joint-state-publisher
+  # - joint-trajectory-controller
+  # - joint-limits
+  # - xacro
+  # - robot-localization
   # - velodyne
   # - sbg_driver
   # - vision-opencv
-  - ackermann-msgs
+  # - ackermann-msgs
 
-  - gazebo_msgs
-  - gazebo_dev
-  - gazebo_ros
-  - gazebo_plugins
-  - gazebo_ros_control
-  - gazebo_ros_pkgs
+  # - gazebo_msgs
+  # - gazebo_dev
+  # - gazebo_ros
+  # - gazebo_plugins
+  # - gazebo_ros_control
+  # - gazebo_ros_pkgs
 
-  - turtlebot3_gazebo
-  - plotjuggler-ros
-  - plotjuggler
+  # - turtlebot3_gazebo
+  # - plotjuggler-ros
+  # - plotjuggler
 
 patch_dir: patch


### PR DESCRIPTION
This PR adds the following ros2_controllers:

    ackermann-steering-controller
    admittance-controller
    forward-command-controller

and it updates control_msgs

This PR is fixing https://github.com/RoboStack/ros-humble/issues/79 and supersedes #80 (as it targets the main branch)