### PR TITLE
Add 3 other controllers from ros2_controllers.

### DIFF
--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -52,12 +52,14 @@ packages_select_by_deps:
   # - foxglove_bridge
   # - turtlebot3
 
-  - control_msgs
-  - steering-controllers-library
-  - ackermann-steering-controller
-  - admittance-controller  
-  - forward-command-controller
-
+  #- control_msgs
+  #- steering-controllers-library
+  #- ackermann-steering-controller
+  #- admittance-controller
+  #- forward-command-controller
+  - bicycle_steering_controller
+  - diff_drive_controller
+  - effort_controllers
   # - joint-state-broadcaster
   # - joint-state-publisher
   # - joint-trajectory-controller


### PR DESCRIPTION
This PR adds three other controllers:
  - bicycle_steering_controller
  - diff_drive_controller
  - effort_controllers

This PR is using the same approach than the previous PR only adding new packages.