### PR TITLE
Update ros-humble-google-benchmark-vendor.patch to reflect upstream change

### DIFF
--- a/patch/ros-humble-google-benchmark-vendor.patch
+++ b/patch/ros-humble-google-benchmark-vendor.patch
@@ -17,11 +17,11 @@ index d5e34a0..5eb4fae 100644
  
  macro(build_benchmark)
    set(extra_cmake_args)
-@@ -79,18 +73,6 @@ macro(build_benchmark)
+@@ -80,18 +73,6 @@ macro(build_benchmark)
    )
  endmacro()
  
--if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.6.1)
+-if(NOT benchmark_FOUND OR "${benchmark_VERSION}" VERSION_LESS 1.5.3)
 -  build_benchmark()
 -elseif(benchmark_FOUND)
 -  # Ubuntu Focal and Jammy have a packaging bug where libbenchmark_main has no symbols,


### PR DESCRIPTION
vinca generated recipe ask for 
https://github.com/ros2-gbp/google_benchmark_vendor-release/blob/release/humble/google_benchmark_vendor/0.1.2-1/CMakeLists.txt#L15
which needs the updated patch files