### PR TITLE
add python38 compatbility to rebuilt_2024 branch

### DIFF
--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -1,3 +1,5 @@
+ament_package:
+  add_host: ['importlib_resources']
 foxglove_bridge:
   add_host: ["ros-humble-ament-cmake"]
 ros_ign_interfaces:

--- a/patch/ros-humble-ament-package.patch
+++ b/patch/ros-humble-ament-package.patch
@@ -24,7 +24,13 @@ diff --git a/ament_package/templates.py b/ament_package/templates.py
 index 8fda08d..497f0c8 100644
 --- a/ament_package/templates.py
 +++ b/ament_package/templates.py
-@@ -22,10 +22,15 @@ except ModuleNotFoundError:
+@@ -18,13 +18,19 @@ 
+ try:
+     import importlib.resources as importlib_resources
++    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
+-except ModuleNotFoundError:
++except (ModuleNotFoundError, AttributeError):
+     import importlib_resources
  
  IS_WINDOWS = os.name == 'nt'
  


### PR DESCRIPTION
importlib.resource.files is only [available in python>3.9 ](https://docs.python.org/3/library/importlib.resources.html#importlib.resources.files).
So we fallback to use request_resource package when the `files` function isn't available.