### PR TITLE
fix a broken ros-humble-ament-package.patch 

### DIFF
--- a/patch/ros-humble-ament-package.patch
+++ b/patch/ros-humble-ament-package.patch
@@ -21,14 +21,15 @@ index 292e518..0000000
 -fi
 -unset _IS_DARWIN
 diff --git a/ament_package/templates.py b/ament_package/templates.py
-index 8fda08d..497f0c8 100644
+index 885b972..463453c 100644
 --- a/ament_package/templates.py
 +++ b/ament_package/templates.py
-@@ -18,13 +18,19 @@ 
+@@ -17,15 +17,21 @@ import re
+ 
  try:
      import importlib.resources as importlib_resources
-+    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
 -except ModuleNotFoundError:
++    assert importlib_resources.files, "importlib reousrces too old to support files, please install importlib_resources"
 +except (ModuleNotFoundError, AttributeError):
      import importlib_resources
  
@@ -48,7 +49,7 @@ index 8fda08d..497f0c8 100644
  
  
  def get_package_level_template_names(all_platforms=False):
-@@ -41,8 +46,9 @@ def get_package_level_template_names(all_platforms=False):
+@@ -41,8 +47,9 @@ def get_package_level_template_names(all_platforms=False):
  
  
  def get_package_level_template_path(name):
@@ -60,7 +61,7 @@ index 8fda08d..497f0c8 100644
  
  
  def get_prefix_level_template_names(*, all_platforms=False):
-@@ -61,8 +67,9 @@ def get_prefix_level_template_names(*, all_platforms=False):
+@@ -61,8 +68,9 @@ def get_prefix_level_template_names(*, all_platforms=False):
  
  
  def get_prefix_level_template_path(name):
@@ -71,5 +72,16 @@ index 8fda08d..497f0c8 100644
 +    return str(path)
  
  
- def configure_file(template_file, environment):
+ def get_isolated_prefix_level_template_names(*, all_platforms=False):
+@@ -81,8 +89,9 @@ def get_isolated_prefix_level_template_names(*, all_platforms=False):
  
+ 
+ def get_isolated_prefix_level_template_path(name):
+-    with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
+-        return str(path)
++    #with importlib_resources.path('ament_package.template.isolated_prefix_level', name) as path:
++    path = importlib_resources.files('ament_package.template.isolated_prefix_level').joinpath(name)
++    return str(path)
+ 
+ 
+ def configure_file(template_file, environment):


### PR DESCRIPTION
The patch in #127 was problematic due to manually edited patch file
I have regenerated one and ensure my local built is successful. 

I've also migrated `get_isolated_prefix_level_template_path`.