### PR TITLE
Add realsense support

### DIFF
--- a/patch/ros-humble-librealsense2.patch
+++ b/patch/ros-humble-librealsense2.patch
@@ -1,0 +1,16 @@
+index ce3b560..ffa6612 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,10 +11,7 @@ include_directories(${REPO_ROOT})
+ include(CMake/lrs_options.cmake)
+ include(CMake/connectivity_check.cmake)
+ #Deprecation message, should be removed in future releases
+-if(${FORCE_LIBUVC} OR ${FORCE_WINUSB_UVC} OR ${ANDROID_USB_HOST_UVC})
+-    MESSAGE(DEPRECATION "FORCE_LIBUVC, FORCE_WINUSB_UVC and ANDROID_USB_HOST_UVC are deprecated, use FORCE_RSUSB_BACKEND instead")
+-    set(FORCE_RSUSB_BACKEND ON)
+-endif()
++set(FORCE_RSUSB_BACKEND ON)
+ 
+ # Checking Internet connection, as DEPTH CAM needs to download the FW from amazon cloud
+ if(IMPORT_DEPTH_CAM_FW AND NOT INTERNET_CONNECTION)
+

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -378,7 +378,7 @@ packages_select_by_deps:
   # - launch-system-modes
   # - lgsvl-msgs
   # - libmavconn
-  # - librealsense2
+  - librealsense2
   # - marti-can-msgs
   # - marti-common-msgs
   # - marti-dbw-msgs
@@ -428,9 +428,9 @@ packages_select_by_deps:
   # - rc-reason-clients
   # - rc-reason-msgs
   # - rcss3d-agent
-  # - realsense2-camera
-  # - realsense2-camera-msgs
-  # - realsense2-description
+  - realsense2-camera
+  - realsense2-camera-msgs
+  - realsense2-description
   # - realtime-tools
   # - rmf-battery
   # - rmf-building-map-msgs


### PR DESCRIPTION
### Patch outline
* patch  set FORCE_RSUSB_BACKEND=ON as default option to fix v4l2 incompatibility issue with conda sysroot.
* `FORCE_RSUSB_BACKEND` is the [recommended setting](https://dev.intelrealsense.com/docs/build-configuration#back-end-recommended-configuration) for windows/mac 
* `FORCE_RSUSB_BACKEND=ON` align with official realsense [conda-forge feedstock](https://github.com/conda-forge/librealsense-feedstock/blob/main/recipe/build.sh#L45).
* compiled binary tested working hardware (see below)
* PR targeted at rebuild_2024 instead of main as the conda_pinnings in main are too old to create build environment. On the contrary it work in rebuild_2024

### compilation error w/o patch
```
FAILED: CMakeFiles/realsense2.dir/src/linux/backend-v4l2.cpp.o                                                                                                                                                         
$BUILD_PREFIX/bin/x86_64-conda-linux-gnu-c++ -DBUILD_EASYLOGGINGPP -DBUILD_SHARED_LIBS -DCOM_MULTITHREADED -DEASYLOGGINGPP_ASYNC -DELPP_NO_DEFAULT_LOG_FILE -DELPP_THREAD_SAFE -DHWM_OVER_XU -DRS2_USE_V4L2_BACKEND -DU
NICODE -DUSING_UDEV -Drealsense2_EXPORTS -I$SRC_DIR/ros-humble-librealsense2/src/work -I$SRC_DIR/ros-humble-librealsense2/src/work/src -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/c
onsole_bridge/include -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/cpp_common/include -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/rosbag_storage/i
nclude -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/roscpp_serialization/include -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/rostime/include -I$SR
C_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/roscpp_traits/include -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/rosbag/roslz4/include -I$SRC_DIR/ros-humble-lib
realsense2/src/work/third-party/realsense-file/rosbag/msgs -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/realsense-file/lz4/lib -I$SRC_DIR/ros-humble-librealsense2/src/work/include -I$PREFIX/include/libus
b-1.0 -I$SRC_DIR/ros-humble-librealsense2/src/work/third-party/rsutils/include -fvisibility-inlines-hidden -fmessage-length=0 -march=nocona -mtune=haswell -ftree-vectorize -fPIC -fstack-protector-strong -fno-plt -O2
 -ffunction-sections -pipe -isystem $PREFIX/include -fdebug-prefix-map=$SRC_DIR=/usr/local/src/conda/ros-humble-librealsense2-2.54.1 -fdebug-prefix-map=$PREFIX=/usr/local/src/conda-prefix -fdiagnostics-color=always 
-D__STDC_FORMAT_MACROS=1 -pedantic -g -Wno-missing-field-initializers -Wno-switch -Wno-multichar -Wsequence-point -Wformat -Wformat-security -mssse3 -pthread -O3 -DNDEBUG -fPIC -MD -MT CMakeFiles/realsense2.dir/src/
linux/backend-v4l2.cpp.o -MF CMakeFiles/realsense2.dir/src/linux/backend-v4l2.cpp.o.d -o CMakeFiles/realsense2.dir/src/linux/backend-v4l2.cpp.o -c $SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cp
p                                                                                                                                                                                                                      
In file included from $SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:5:                                                                                                                         
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.h:46:111: note: '#pragma message:                                                                                                                    
Librealsense notification: V4L2_META_FMT_UVC was not defined, adding metadata constructs'                                                                                                                              
   46 | #pragma message ( "\nLibrealsense notification: V4L2_META_FMT_UVC was not defined, adding metadata constructs")                                                                                                
      |                                                                                                               ^                                                                                                
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp: In member function 'virtual bool librealsense::platform::v4l_mipi_device::set_xu(const librealsense::platform::extension_unit&, uint8_t, const u
int8_t*, int)':                                                                                                                                                                                                        
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2419:27: error: 'struct v4l2_ext_control' has no member named 'p_u8'                                                                             
 2419 |                     xctrl.p_u8 = const_cast<uint8_t*>(data); // TODO aggregate initialization with union                                                                                                       
      |                           ^~~~                                                                                                                                                                                 
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp: In member function 'virtual bool librealsense::platform::v4l_mipi_device::get_xu(const librealsense::platform::extension_unit&, uint8_t, uint8_t
*, int) const':                                                                                                                                                                                                        
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2442:19: error: 'struct v4l2_ext_control' has no member named 'p_u8'                                                                             
 2442 |             xctrl.p_u8 = data;
      |                   ^~~~
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp: In member function 'virtual librealsense::platform::control_range librealsense::platform::v4l_mipi_device::get_xu_range(const librealsense::plat
form::extension_unit&, uint8_t, int) const':
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2477:13: error: 'v4l2_query_ext_ctrl' was not declared in this scope; did you mean 'v4l2_queryctrl'?
 2477 |             v4l2_query_ext_ctrl xctrl_query{};
      |             ^~~~~~~~~~~~~~~~~~~
      |             v4l2_queryctrl
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2478:13: error: 'xctrl_query' was not declared in this scope
 2478 |             xctrl_query.id = xu_to_cid(xu,control);
      |             ^~~~~~~~~~~
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2480:30: error: 'VIDIOC_QUERY_EXT_CTRL' was not declared in this scope; did you mean 'VIDIOC_TRY_EXT_CTRLS'?
 2480 |             if(0 > ioctl(_fd,VIDIOC_QUERY_EXT_CTRL,&xctrl_query)){
      |                              ^~~~~~~~~~~~~~~~~~~~~
      |                              VIDIOC_TRY_EXT_CTRLS
$SRC_DIR/ros-humble-librealsense2/src/work/src/linux/backend-v4l2.cpp:2496:109: error: could not convert '{<expression error>, <expression error>, <expression error>, <expression error>}' from '<brace-enclosed initi
alizer list>' to 'librealsense::platform::control_range'
 2496 |                      static_cast<int32_t>(xctrl_query.step), static_cast<int32_t>(xctrl_query.default_value)};
      |                                                                                                             ^
      |                                                                                                             |
      |                                                                                                             <brace-enclosed initializer list>

```

### Test with realsense D435 hardware
```
(test) $ ros2 run realsense2_camera realsense2_camera_node 
[INFO] [1706432684.213705027] [camera]: RealSense ROS v4.54.1
[INFO] [1706432684.213745613] [camera]: Built with LibRealSense v2.54.1
[INFO] [1706432684.213755061] [camera]: Running with LibRealSense v2.54.1
[INFO] [1706432684.487694654] [camera]: Device with serial number 934222072381 was found.

[INFO] [1706432684.487779725] [camera]: Device with physical ID 12-3-2 was found.
[INFO] [1706432684.487794673] [camera]: Device with name Intel RealSense D435 was found.
[INFO] [1706432684.488027423] [camera]: Device with port number 12-3 was found.
[INFO] [1706432684.488047070] [camera]: Device USB type: 3.2
[INFO] [1706432684.488916244] [camera]: getParameters...
[INFO] [1706432684.489210781] [camera]: JSON file is not provided
[INFO] [1706432684.489228334] [camera]: Device Name: Intel RealSense D435
[INFO] [1706432684.489236950] [camera]: Device Serial No: 934222072381
[INFO] [1706432684.489244755] [camera]: Device physical port: 12-3-2
[INFO] [1706432684.489251828] [camera]: Device FW version: 5.11.15
[INFO] [1706432684.489259112] [camera]: Device Product ID: 0x0B07
[INFO] [1706432684.489265735] [camera]: Sync Mode: Off
[INFO] [1706432687.064861403] [camera]: Stopping Sensor: Depth Module
[INFO] [1706432687.276135505] [camera]: Starting Sensor: Depth Module
[INFO] [1706432687.424555989] [camera]: Open profile: stream_type: Infra(1), Format: Y8, Width: 848, Height: 480, FPS: 30
[INFO] [1706432687.424605973] [camera]: Open profile: stream_type: Infra(2), Format: Y8, Width: 848, Height: 480, FPS: 30
[INFO] [1706432687.424615251] [camera]: Open profile: stream_type: Depth(0), Format: Z16, Width: 848, Height: 480, FPS: 30
[INFO] [1706432687.424773730] [camera]: Stopping Sensor: RGB Camera
 28/01 01:04:47,424 WARNING [140680462571072] (messenger-libusb.cpp:42) control_transfer returned error, index: 768, error: Resource temporarily unavailable, number: 11
 28/01 01:04:47,435 WARNING [140680462571072] (messenger-libusb.cpp:42) control_transfer returned error, index: 768, error: Resource temporarily unavailable, number: 11
[INFO] [1706432687.445705999] [camera]: Starting Sensor: RGB Camera
[INFO] [1706432687.468281737] [camera]: Open profile: stream_type: Color(0), Format: RGB8, Width: 640, Height: 480, FPS: 30
[INFO] [1706432687.469116907] [camera]: RealSense Node Is Up!
[WARN] [1706432687.546007617] [camera]: 

```