### PR TITLE
Use libboost-* packages instead of deprecated boost and boost-cpp packages

### DIFF
--- a/additional_recipes/ros2-distro-mutex/recipe.yaml
+++ b/additional_recipes/ros2-distro-mutex/recipe.yaml
@@ -17,7 +17,6 @@ requirements:
   # This has to be synchronized with our current conda_build_config all the time :(
   # host:
   #   # values here should 
-  #   - boost-cpp
   #   - log4cxx
   #   - poco
   #   - pcl
@@ -30,7 +29,7 @@ requirements:
   # if the upstream package does not have run_exports
   # please change it in the conda_build_config.yaml!
   run_constrained:
-    - boost-cpp 1.82
+    - libboost 1.82
     - libboost-devel 1.82
     - pcl 1.13.1
     - gazebo 11

--- a/patch/dependencies.yaml
+++ b/patch/dependencies.yaml
@@ -42,8 +42,8 @@ pcl_ros:
 rviz_rendering:
   add_host: ["glew"]
 behaviortree_cpp_v3:
-  add_host: ["boost-cpp", "cppzmq"]
-  add_run: ["boost-cpp"]
+  add_host: ["libboost-devel", "cppzmq"]
+  add_run: ["libboost"]
 plotjuggler:
   add_host: ["libxcb", {sel(linux): elfutils}, "ros-humble-ros-workspace"]
 embree_vendor:
@@ -57,7 +57,7 @@ ign_rviz_plugins:
 image_view:
   add_host: ["REQUIRE_OPENGL"]
 nao_lola:
-  add_host: ["boost"]
+  add_host: ["libboost-devel"]
 ros_ign_gazebo:
   add_host: ["ros-humble-std-msgs", "ros-humble-rclcpp", "REQUIRE_OPENGL"]
 ros_ign_gazebo_demos:
@@ -73,8 +73,8 @@ libg2o:
 fmilibrary_vendor:
   add_host: ["fmilib"]
 mrpt2:
-  add_host:  ["assimp", "octomap", "tinyxml2", "boost-cpp", "jsoncpp", "gtest", "boost", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-humble-octomap"]
-  add_run:   ["assimp", "octomap", "tinyxml2", "boost-cpp", "jsoncpp", "gtest", "boost", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-humble-octomap"]
+  add_host:  ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-humble-octomap"]
+  add_run:   ["assimp", "octomap", "tinyxml2", "libboost-devel", "jsoncpp", "gtest", "libboost-python-devel", "libdc1394", "xorg-libxcomposite", "libftdi", "ros-humble-octomap"]
   add_build: [{"sel(linux)": "{{ cdt('libxcomposite-devel') }}"}]
 ros1_rosbag_storage_vendor:
   add_host: ["ros-noetic-roscpp", "ros-noetic-roslz4", "ros-noetic-rostest"]
@@ -89,7 +89,7 @@ nav2_smac_planner:
   add_build: [{"sel(osx)": "llvm-openmp"}]
   add_host: [{"sel(osx)": "llvm-openmp"}, "ompl", "libode"]
 nav2_util:
-  add_host: ["boost-cpp"]
+  add_host: ["libboost-devel"]
 nav2_constrained_smoother:
   add_host: [{"sel(win)": "openblas"}]
 ompl:

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -34,7 +34,7 @@ binutils:
 bison:
   robostack: [bison]
 boost:
-  robostack: [boost]
+  robostack: [libboost-devel, libboost-python-devel]
 bullet:
   robostack: [bullet]
 bzip2:
@@ -185,45 +185,45 @@ libabsl-dev:
 libblas-dev:
   robostack: [libblas, libcblas]
 libboost-chrono-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-date-time:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-date-time-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-filesystem:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-filesystem-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-iostreams-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-program-options:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-program-options-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-python:
-  robostack: [boost]
+  robostack: [libboost-python]
 libboost-python-dev:
-  robostack: [boost]
+  robostack: [libboost-python-devel]
 libboost-random:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-random-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-regex-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-serialization:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-serialization-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-system:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-system-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libboost-thread:
-  robostack: [boost-cpp]
+  robostack: [libboost]
 libboost-thread-dev:
-  robostack: [boost-cpp]
+  robostack: [libboost-devel]
 libcairo2-dev:
   robostack: [cairo]
 libcap-dev:


### PR DESCRIPTION
As reported in https://github.com/RoboStack/ros-noetic/issues/448#issuecomment-1962127319, the use of deprecated packages that were not pinned in pinnings was basically causing the pinning to be ignored. With respect to ROS Noetic, we do not need to do any kind of rebuild as we have a `run_constrained` on `boost-cpp` in `ros2-distro-mutex`, that is not there in ROS Noetic.