### PR TITLE
Add joint-state-publisher-gui to Windows packages

### DIFF
--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -62,6 +62,7 @@ packages_select_by_deps:
   # ros2_control
   - gazebo-ros2-control
   - ros2-controllers-test-nodes
+  - joint-state-publisher-gui
 
   # PREVIOUSLY SUPPORTED PACKAGES, CURRENTLY BROKEN
   # Currently has upstream issues with git LFS


### PR DESCRIPTION
Follow up to https://github.com/RoboStack/ros-humble/pull/158, now the installation works fine on Linux but on Windows a package is still missing.