### PR TITLE
add additional patches for gcc 13 and fix rosidl py generator patch on linux

### DIFF
--- a/patch/ros-humble-libstatistics-collector.patch
+++ b/patch/ros-humble-libstatistics-collector.patch
@@ -1,0 +1,12 @@
+diff --git a/include/libstatistics_collector/moving_average_statistics/types.hpp b/include/libstatistics_collector/moving_average_statistics/types.hpp
+index eb58531..c253f23 100644
+--- a/include/libstatistics_collector/moving_average_statistics/types.hpp
++++ b/include/libstatistics_collector/moving_average_statistics/types.hpp
+@@ -18,6 +18,7 @@
+ #include <cmath>
+ #include <sstream>
+ #include <string>
++#include <cstdint>
+ 
+ #include "libstatistics_collector/visibility_control.hpp"
+ 

--- a/patch/ros-humble-rosbag2-compression.patch
+++ b/patch/ros-humble-rosbag2-compression.patch
@@ -1,0 +1,12 @@
+diff --git a/include/rosbag2_compression/compression_options.hpp b/include/rosbag2_compression/compression_options.hpp
+index 37fe5007e..191bb6d71 100644
+--- a/include/rosbag2_compression/compression_options.hpp
++++ b/include/rosbag2_compression/compression_options.hpp
+@@ -16,6 +16,7 @@
+ #define ROSBAG2_COMPRESSION__COMPRESSION_OPTIONS_HPP_
+ 
+ #include <string>
++#include <cstdint>
+ 
+ #include "visibility_control.hpp"
+ 

--- a/patch/ros-humble-rosidl-generator-py.patch
+++ b/patch/ros-humble-rosidl-generator-py.patch
@@ -65,7 +65,7 @@ index a6d8263..f231ea2 100644
 +  set_target_properties(${_target_name_lib} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
 +  target_include_directories(${_target_name_lib} PUBLIC ${Python3_INCLUDE_DIRS} ${Python3_NumPy_INCLUDE_DIRS})
 +else()
-+  target_link_libraries(${_target_name_lib} PUBLIC Python3::NumPy Python3::Module Python3::Python)
++  target_link_libraries(${_target_name_lib} PRIVATE Python3::NumPy Python3::Python)
  endif()
  
  rosidl_get_typesupport_target(c_typesupport_target "${rosidl_generate_interfaces_TARGET}" "rosidl_typesupport_c")


### PR DESCRIPTION
I had to make the linkage PRIVATE to work on Linux (and not complain later on).

And I had to add 2x `cstdint` header because `gcc 13` requires it.