### PR TITLE
Inject libprotobuf and libabseil dependency if a package depends on Gazebo Classic

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -100,11 +100,11 @@ g++-static:
 gawk:
   robostack: [gawk]
 gazebo:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo11:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 gazebo9:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 geographiclib:
   robostack: [geographiclib-cpp]
 geographiclib-tools:
@@ -264,9 +264,9 @@ libfreetype6-dev:
 libftdi-dev:
   robostack: [libftdi, libusb]
 libgazebo11-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgazebo9-dev:
-  robostack: [gazebo]
+  robostack: [gazebo, libprotobuf, libabseil]
 libgdal-dev:
   robostack: [libgdal]
 libgeos++-dev:


### PR DESCRIPTION
Workaround for:
* https://github.com/RoboStack/ros-humble/issues/175
* https://github.com/conda-forge/gazebo-feedstock/issues/107

Similar to https://github.com/RoboStack/ros-noetic/pull/464 .

It will be only useful after a rebuild, but let's do it so it is there when we do a rebuild.