### PR TITLE
bump builds on all vincas, ros2_control, ros2_controllers, control-toolbox, gazebo-ros2-control

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 6
+build_number: 7
 
 mutex_package: ros2-distro-mutex 0.5 humble
 
@@ -35,110 +35,112 @@ skip_existing:
   - https://conda.anaconda.org/robostack-staging/
 
 packages_select_by_deps:
+
   # only subset of packages to reduce maintainer load
   # trigger
-  - qt-qui-cpp # needs to be compiled locally
 
-  - generator-dds-idl
-  - ros_workspace
-  - ros_environment
-  - ament_cmake
-  - ros_base
-  - desktop
-  - navigation2
-  - graph_msgs
-  - nav2_bringup
-  - turtlebot3
-  - desktop_full
-  - apriltag
-  - turtlebot3_fake_node
-  - ur
-  - ublox
-  - robot_localization
-  - topic_tools
-  - stubborn_buddies
-  - teleop_tools
-  - udp_driver
-  - urdf_tutorial
-  - test_bond
-  - apex_test_tools
-  - ublox_dgnss
-  - velodyne_description
-  - velodyne
-  - visp
-  - apex_containers
-  - apex_test_tools
-  - bno055
-  - aws_robomaker_small_warehouse_world
-  - avt_vimba_camera
-  - ros_ign
-  - spacenav
-  - system_modes
-  - tf_transformations
-  - turtle_tf2_cpp
-  - turtle_tf2_py
-  - ros2controlcli
-  - robot_controllers
+  # -- build 7 re-select --
   - ros2_control
   - ros2_controllers
   - control-toolbox
-  - joint-trajectory-controller
-  - gazebo-dev
-  - gazebo-plugins
-  - gazebo-ros
-  - gazebo-ros-pkgs
-  - turtlebot3_gazebo
-  - turtlebot3_simulations
-  - rqt
-  - rqt_image_overlay
-  - rqt-robot-dashboard
-  - rqt-robot-monitor
-  - rqt-robot-steering
-  - joint-state-broadcaster
-  - joint-state-publisher
-  - xacro
-  - image-pipeline
-  - image-view
-  - bond-core
-  - camera-calibration
-  - camera-calibration-parsers
-  - camera-info-manager
-  - slam-toolbox
-  - foxglove_bridge
-  - ament-cmake-nose
-  - geographic_info
-  - geodesy
-  - rosbridge_suite
-  - ament_cmake_catch2
-  - apriltag
-  - apriltag_ros
-  - marker-msgs
-  - moveit
-  - moveit-ros-perception
-  - moveit-runtime
-  - moveit-servo
-  - moveit_visual_tools
-  - moveit_servo
-  - moveit2_tutorials
-  - moveit-planners-chomp
-  - rqt-moveit
-
-  - librealsense2
-  - realsense2-camera
-  - realsense2-camera-msgs
-  - realsense2-description
-  - webots_ros2
-  - rosidl-generator-dds-idl
-
-  - ros2_control
   - gazebo-ros2-control
 
-  # Modern gz-sim integration
-  - ros-gz
-  - libg2o
+  # - qt-qui-cpp # needs to be compiled locally
 
-  - gtsam
-  - motion-capture-tracking
+  # - generator-dds-idl
+  # - ros_workspace
+  # - ros_environment
+  # - ament_cmake
+  # - ros_base
+  # - desktop
+  # - navigation2
+  # - graph_msgs
+  # - nav2_bringup
+  # - turtlebot3
+  # - desktop_full
+  # - apriltag
+  # - turtlebot3_fake_node
+  # - ur
+  # - ublox
+  # - robot_localization
+  # - topic_tools
+  # - stubborn_buddies
+  # - teleop_tools
+  # - udp_driver
+  # - urdf_tutorial
+  # - test_bond
+  # - apex_test_tools
+  # - ublox_dgnss
+  # - velodyne_description
+  # - velodyne
+  # - visp
+  # - apex_containers
+  # - apex_test_tools
+  # - bno055
+  # - aws_robomaker_small_warehouse_world
+  # - avt_vimba_camera
+  # - ros_ign
+  # - spacenav
+  # - system_modes
+  # - tf_transformations
+  # - turtle_tf2_cpp
+  # - turtle_tf2_py
+  # - ros2controlcli
+  # - robot_controllers
+  # - joint-trajectory-controller
+  # - gazebo-dev
+  # - gazebo-plugins
+  # - gazebo-ros
+  # - gazebo-ros-pkgs
+  # - turtlebot3_gazebo
+  # - turtlebot3_simulations
+  # - rqt
+  # - rqt_image_overlay
+  # - rqt-robot-dashboard
+  # - rqt-robot-monitor
+  # - rqt-robot-steering
+  # - joint-state-broadcaster
+  # - joint-state-publisher
+  # - xacro
+  # - image-pipeline
+  # - image-view
+  # - bond-core
+  # - camera-calibration
+  # - camera-calibration-parsers
+  # - camera-info-manager
+  # - slam-toolbox
+  # - foxglove_bridge
+  # - ament-cmake-nose
+  # - geographic_info
+  # - geodesy
+  # - rosbridge_suite
+  # - ament_cmake_catch2
+  # - apriltag
+  # - apriltag_ros
+  # - marker-msgs
+  # - moveit
+  # - moveit-ros-perception
+  # - moveit-runtime
+  # - moveit-servo
+  # - moveit_visual_tools
+  # - moveit_servo
+  # - moveit2_tutorials
+  # - moveit-planners-chomp
+  # - rqt-moveit
+
+  # - librealsense2
+  # - realsense2-camera
+  # - realsense2-camera-msgs
+  # - realsense2-description
+  # - webots_ros2
+  # - rosidl-generator-dds-idl
+
+  # Modern gz-sim integration
+  # - ros-gz
+  # - libg2o
+
+  # - gtsam
+  # - motion-capture-tracking
 
   # Needs fixing
   # - moveit-resources

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 4
+build_number: 5
 
 mutex_package: ros2-distro-mutex 0.5 humble
 
@@ -38,62 +38,65 @@ skip_existing:
 
 packages_select_by_deps:
   # only subset of packages to reduce maintainer load
-  - ros2-controllers
-  - diff-drive-controller
-  - libcamera
-  - ros_workspace
-  - ros_environment
-  - ament_cmake
-  - ros_base
-  - desktop
-  - desktop_full
-  - rosbag2_storage_mcap
-  - cartographer-ros
-  - foxglove_bridge
 
-  - gazebo_msgs
-  - gazebo_dev
-  - gazebo_ros
-  - gazebo_plugins
-  - gazebo_ros2_control
-  - gazebo_ros_pkgs
+  # only subset of packages to reduce maintainer load
+  # trigger
 
-  - ackermann-msgs
-  - velodyne
-  - geodesy
-  - geographic_info
-  - tf-transformations
-  - robot_localization
-
-  - rosbridge_suite
-  - vision-msgs
-  - slam-toolbox
-
+  # -- build 5 re-select --
   - ros2_control
-  - vision-msgs-rviz-plugins
-
-  - navigation2
-  - rviz2
-  - behaviortree_cpp_v3
-  - ament_cmake_catch2
-
-  - apriltag
-  - apriltag_ros
-
-  - moveit
-  - moveit_servo
-  - moveit-planners-chomp
-
-  # - control_toolbox
-  # - ros1_bridge
-
-  # ros2_control
+  - ros2_controllers
+  - control-toolbox
   - gazebo-ros2-control
 
-  # Modern gz-sim integration
-  - ros-gz
+  # - diff-drive-controller
+  # - libcamera
+  # - ros_workspace
+  # - ros_environment
+  # - ament_cmake
+  # - ros_base
+  # - desktop
+  # - desktop_full
+  # - rosbag2_storage_mcap
+  # - cartographer-ros
+  # - foxglove_bridge
 
-  - gtsam
+  # - gazebo_msgs
+  # - gazebo_dev
+  # - gazebo_ros
+  # - gazebo_plugins
+  # - gazebo_ros_pkgs
+
+  # - ackermann-msgs
+  # - velodyne
+  # - geodesy
+  # - geographic_info
+  # - tf-transformations
+  # - robot_localization
+
+  # - rosbridge_suite
+  # - vision-msgs
+  # - slam-toolbox
+
+  # - vision-msgs-rviz-plugins
+
+  # - navigation2
+  # - rviz2
+  # - behaviortree_cpp_v3
+  # - ament_cmake_catch2
+
+  # - apriltag
+  # - apriltag_ros
+
+  # - moveit
+  # - moveit_servo
+  # - moveit-planners-chomp
+
+  # - ros1_bridge
+
+  # Modern gz-sim integration
+  # - ros-gz
+
+  # - gtsam
 
   # Used to work, now needs fixes
   # - rtabmap
@@ -215,7 +218,6 @@ packages_select_by_deps:
   # - compressed-depth-image-transport
   # - compressed-image-transport
   # - control-box-rst
-  # - control-toolbox
   # - depth-image-proc
   # - diagnostic-aggregator
   # - diagnostic-updater

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 6
+build_number: 7
 
 mutex_package: ros2-distro-mutex 0.5 humble
 
@@ -38,71 +38,72 @@ skip_existing:
   - https://conda.anaconda.org/robostack-staging/
 
 packages_select_by_deps:
+
+  # only subset of packages to reduce maintainer load
   # trigger
-  - ros_workspace
-  - ros_environment
-  - ros_base
-  - desktop
-  - desktop_full
-  - navigation2
-  - rosbridge_suite
-  - vision_msgs
-  - rosbag2_storage_mcap
-  - foxglove_bridge
-  - turtlebot3
 
-  - control_msgs
-  - steering-controllers-library
-  - ackermann-steering-controller
-  - admittance-controller
-  - forward-command-controller
-  - bicycle_steering_controller
-  - diff_drive_controller
-  - effort_controllers
-  - force_torque_sensor_broadcaster
-  - imu_sensor_broadcaster
-  - position_controllers
-
+  # -- build 7 re-select --
   - ros2_control
   - ros2_controllers
+  - control-toolbox
+  - gazebo-ros2-control
 
-  - joint-state-broadcaster
-  - joint-state-publisher
-  - joint-trajectory-controller
-  - joint-limits
-  - xacro
-  - robot-localization
-  - velodyne
-  - sbg_driver
-  - vision-opencv
-  - ackermann-msgs
-  - ament_cmake_catch2
+  # - ros_workspace
+  # - ros_environment
+  # - ros_base
+  # - desktop
+  # - desktop_full
+  # - navigation2
+  # - rosbridge_suite
+  # - vision_msgs
+  # - rosbag2_storage_mcap
+  # - foxglove_bridge
+  # - turtlebot3
 
-  - gazebo_msgs
-  - gazebo_dev
-  - gazebo_ros
-  - gazebo_plugins
-  - gazebo_ros_pkgs
+  # - control_msgs
+  # - steering-controllers-library
+  # - ackermann-steering-controller
+  # - admittance-controller
+  # - forward-command-controller
+  # - bicycle_steering_controller
+  # - diff_drive_controller
+  # - effort_controllers
+  # - force_torque_sensor_broadcaster
+  # - imu_sensor_broadcaster
+  # - position_controllers
 
-  - turtlebot3_gazebo
-  - plotjuggler-ros
-  - plotjuggler
+  # - joint-state-broadcaster
+  # - joint-state-publisher
+  # - joint-trajectory-controller
+  # - joint-limits
+  # - xacro
+  # - robot-localization
+  # - velodyne
+  # - sbg_driver
+  # - vision-opencv
+  # - ackermann-msgs
+  # - ament_cmake_catch2
 
-  - apriltag
-  - apriltag_ros
+  # - gazebo_msgs
+  # - gazebo_dev
+  # - gazebo_ros
+  # - gazebo_plugins
+  # - gazebo_ros_pkgs
 
-  # ros2_control
-  - gazebo_ros2_control
-  - ros2_control
-  - ros2_controllers
+  # - turtlebot3_gazebo
+  # - plotjuggler-ros
+  # - plotjuggler
+
+  # - apriltag
+  # - apriltag_ros
 
   # Modern gz-sim integration
-  - ros-gz
+  # - ros-gz
 
-  - moveit
-  - moveit_servo
-  - moveit-planners-chomp
+  # - moveit
+  # - moveit_servo
+  # - moveit-planners-chomp
 
-  - gtsam
+  # - gtsam
 
 patch_dir: patch

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 5
+build_number: 6
 
 mutex_package: ros2-distro-mutex 0.5 humble
 
@@ -38,61 +38,64 @@ skip_existing:
   # - /Users/fischert/mambaforge/envs/devenv/conda-bld/
 
 packages_select_by_deps:
+
+  # only subset of packages to reduce maintainer load
   # trigger
-  - ros_workspace
-  - ros_environment
-  - ros_base
-  - demo_nodes_py
-  - demo_nodes_cpp
-  - desktop
-  - graph_msgs
-  - desktop_full
-  - navigation2
-  - rosbridge_suite
-  - vision_msgs
-  - rosbag2_storage_mcap
-  - foxglove_bridge
-  - turtlebot3
 
-  - joint-state-broadcaster
-  - joint-state-publisher
-  - joint-state-publisher-gui
-  - joint-trajectory-controller
-  - xacro
-  - robot-localization
-  - vision-opencv
-
-  - gazebo_msgs
-  - gazebo_dev
-  - gazebo_ros
-  - gazebo_plugins
-  - gazebo_ros2_control
-  - gazebo_ros_pkgs
-  - turtlebot3_gazebo
-
-  - plotjuggler-ros
-  - plotjuggler
-
-  - ament_cmake_catch2
-
-  - apriltag
-  - apriltag_ros
-
-  - velodyne
-  - sbg_driver
-  - ackermann-msgs
-
-  # ros2_control
+  # -- build 6 re-select --
   - ros2_control
   - ros2_controllers
+  - control-toolbox
   - gazebo-ros2-control
 
-  # Modern gz-sim integration
-  - ros-gz
+  # - ros_workspace
+  # - ros_environment
+  # - ros_base
+  # - demo_nodes_py
+  # - demo_nodes_cpp
+  # - desktop
+  # - graph_msgs
+  # - desktop_full
+  # - navigation2
+  # - rosbridge_suite
+  # - vision_msgs
+  # - rosbag2_storage_mcap
+  # - foxglove_bridge
+  # - turtlebot3
 
-  - moveit
-  - moveit-planners-chomp
+  # - joint-state-broadcaster
+  # - joint-state-publisher
+  # - joint-state-publisher-gui
+  # - joint-trajectory-controller
+  # - xacro
+  # - robot-localization
+  # - vision-opencv
 
-  - gtsam
+  # - gazebo_msgs
+  # - gazebo_dev
+  # - gazebo_ros
+  # - gazebo_plugins
+  # - gazebo_ros_pkgs
+  # - turtlebot3_gazebo
+
+  # - plotjuggler-ros
+  # - plotjuggler
+
+  # - ament_cmake_catch2
+
+  # - apriltag
+  # - apriltag_ros
+
+  # - velodyne
+  # - sbg_driver
+  # - ackermann-msgs
+
+  # # Modern gz-sim integration
+  # - ros-gz
+
+  # - moveit
+  # - moveit-planners-chomp
+
+  # - gtsam
 
 patch_dir: patch

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-build_number: 7
+build_number: 8
 
 mutex_package: ros2-distro-mutex 0.5 humble
 
@@ -33,20 +33,27 @@ skip_existing:
   - https://conda.anaconda.org/robostack-staging/
 
 packages_select_by_deps:
+
+  # only subset of packages to reduce maintainer load
   # trigger
-  - ament-cmake-core
-  #- ros2_control
-  #- ros2_controllers
-  - backward_ros
-  - ros_workspace
-  - vision_msgs
-  - ros_environment
-  - ros_base
-  - rmw_cyclonedds_cpp
-  - moveit
-  - moveit-planners-chomp
-  - xacro
-  - gazebo-ros
+
+  # -- build 7 re-select --
+  - ros2_control
+  - ros2_controllers
+  - control-toolbox
+  - gazebo-ros2-control
+
+  # - ament-cmake-core
+  # - backward_ros
+  # - ros_workspace
+  # - vision_msgs
+  # - ros_environment
+  # - ros_base
+  # - rmw_cyclonedds_cpp
+  # - moveit
+  # - moveit-planners-chomp
+  # - xacro
+  # - gazebo-ros
   # - navigation2
   # - desktop
   # - cv_bridge
@@ -55,17 +62,14 @@ packages_select_by_deps:
   # - gazebo_dev
   # - gazebo_ros
   # - gazebo_plugins
-  # - gazebo_ros2_control
   # - gazebo_ros_pkgs
   # - turtlebot3_simulations
   # - rosbridge_suite
   # - ament_cmake_catch2
   # - nav2-mppi-controller
 
-  # ros2_control
-  - gazebo-ros2-control
-  - ros2-controllers-test-nodes
-  - joint-state-publisher-gui
+  # - ros2-controllers-test-nodes
+  # - joint-state-publisher-gui
 
   # Broken for now until we migrate to newer gazebo
   # - desktop_full


### PR DESCRIPTION
Increased build number for all lists as follows and included for build only:
- ros2_control
- ros2_controllers
- control-toolbox
- gazebo-ros-control

Fixes #203 