### PR TITLE
Rebuild lanelet2-io with correct pugixml and ros-humble-ros-workspace with fastrtps fix

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -94,7 +94,7 @@ jobs:
       run: |
         cp vinca_linux_64.yaml vinca.yaml
         mkdir -p recipes
-        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform linux-64 -m -n
+        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform linux-64 -m
         ls -la recipes
     - name: Generate recipes for linux-aarch64
       shell: bash -l {0}
@@ -102,7 +102,7 @@ jobs:
       run: |
         cp vinca_linux_aarch64.yaml vinca.yaml
         mkdir -p recipes
-        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform linux-aarch64 -m -n
+        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform linux-aarch64 -m
         ls -la recipes
     - name: Generate recipes for osx-64
       shell: bash -l {0}
@@ -110,7 +110,7 @@ jobs:
       run: |
         cp vinca_osx.yaml vinca.yaml
         mkdir -p recipes
-        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform osx-64 -m -n
+        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform osx-64 -m
         ls -la recipes
     - name: Generate recipes for osx-arm64
       shell: bash -l {0}
@@ -118,7 +118,7 @@ jobs:
       run: |
         cp vinca_osx_arm64.yaml vinca.yaml
         mkdir -p recipes
-        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform osx-arm64 -m -n
+        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform osx-arm64 -m
         ls -la recipes
     - name: Generate recipes for win-64
       shell: bash -l {0}
@@ -129,7 +129,7 @@ jobs:
         mkdir /c/bld
         cp vinca_win.yaml vinca.yaml
         mkdir -p recipes
-        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform win-64 -m -n
+        $HOME/.pixi/bin/pixi run -e beta -v vinca --platform win-64 -m
         ls -la recipes
     - name: Check if there are packages to be built
       id: newrecipecheck

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -6,6 +6,8 @@ protobuf:
   - 5.28.2
 spdlog:
   - 1.14
+pugixml:
+  - '1.14'
 
 cdt_name:
   - ${{ "cos7" if linux }}

--- a/pixi.lock
+++ b/pixi.lock
@@ -88,7 +88,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+      - pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
       linux-aarch64:
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
@@ -170,7 +170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+      - pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
       osx-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -242,7 +242,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz
-      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+      - pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
       osx-arm64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -314,7 +314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+      - pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
       win-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -394,7 +394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+      - pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
   default:
     channels:
     - url: https://repo.prefix.dev/conda-forge/
@@ -2804,7 +2804,7 @@ packages:
   purls: []
   size: 754247
   timestamp: 1731710681163
-- pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
+- pypi: git+https://github.com/RoboStack/vinca.git@d6e024976249858f25eb0ae07d2c2a46892920d6
   name: vinca
   version: 0.0.4
   requires_dist:

--- a/pixi.lock
+++ b/pixi.lock
@@ -88,7 +88,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
       linux-aarch64:
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
@@ -170,7 +170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
       osx-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -242,7 +242,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz
-      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
       osx-arm64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -314,7 +314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
       win-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -394,7 +394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+      - pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
   default:
     channels:
     - url: https://repo.prefix.dev/conda-forge/
@@ -2804,7 +2804,7 @@ packages:
   purls: []
   size: 754247
   timestamp: 1731710681163
-- pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
+- pypi: git+https://github.com/RoboStack/vinca.git@cc79494f0217655dbd7c84cd17c18ed0b183c6d7
   name: vinca
   version: 0.0.4
   requires_dist:

--- a/pixi.lock
+++ b/pixi.lock
@@ -88,7 +88,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/68/6e/264c50ce2a31473a9fdbf4fa66ca9b2b17c7455b31ef585462343818bd6c/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
       linux-aarch64:
       - conda: https://repo.prefix.dev/conda-forge/linux-aarch64/_openmp_mutex-4.5-2_gnu.tar.bz2
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
@@ -170,7 +170,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/3c/d2/b79b7d695e2f21da020bd44c782490578f300dd44f0a4c57a92575758a76/ruamel.yaml.clib-0.2.12-cp311-cp311-manylinux2014_aarch64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
       osx-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -242,7 +242,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/20/84/80203abff8ea4993a87d823a5f632e4d92831ef75d404c9fc78d0176d2b5/ruamel.yaml.clib-0.2.12.tar.gz
-      - pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
       osx-arm64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -314,7 +314,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/8f/683c6ad562f558cbc4f7c029abcd9599148c51c54b5ef0f24f2638da9fbb/ruamel.yaml.clib-0.2.12-cp311-cp311-macosx_13_0_arm64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
       win-64:
       - conda: https://repo.prefix.dev/conda-forge/noarch/anaconda-client-1.12.3-pyhd8ed1ab_1.conda
       - conda: https://repo.prefix.dev/conda-forge/noarch/attrs-24.3.0-pyh71513ae_0.conda
@@ -394,7 +394,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1c/e2/772f8cff8172a612823755035073b00753613c24af0ed6d3bae215021608/rospkg-1.5.1-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/79/5e2cffa1c77432f11cd93a5351f30732c997a239d3a3090856a72d6d8ba7/ruamel.yaml-0.17.40-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/b4/4f/b52f634c9548a9291a70dfce26ca7ebce388235c93588a1068028ea23fcc/ruamel.yaml.clib-0.2.12-cp311-cp311-win_amd64.whl
-      - pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+      - pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
   default:
     channels:
     - url: https://repo.prefix.dev/conda-forge/
@@ -2804,7 +2804,7 @@ packages:
   purls: []
   size: 754247
   timestamp: 1731710681163
-- pypi: git+https://github.com/RoboStack/vinca.git@aa102b280adcad0374e4d231b25d21bf0db27d61
+- pypi: git+https://github.com/RoboStack/vinca.git@4630c72c9521c0234ef421cc3b0ce6244d9dff42
   name: vinca
   version: 0.0.4
   requires_dist:

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ git = "*"
 
 [feature.beta.pypi-dependencies]
 # This is tipically the latest commit on main branch
-vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "cc79494f0217655dbd7c84cd17c18ed0b183c6d7" }
+vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "d6e024976249858f25eb0ae07d2c2a46892920d6" }
 # Uncomment this line to work with a local vinca for faster iteration, but remember to comment it back
 # (and regenerate the pixi.lock) once you push the modified commit to the repo
 #vinca = { path = "../vinca", editable = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ git = "*"
 
 [feature.beta.pypi-dependencies]
 # This is tipically the latest commit on main branch
-vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "aa102b280adcad0374e4d231b25d21bf0db27d61" }
+vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "4630c72c9521c0234ef421cc3b0ce6244d9dff42" }
 # Uncomment this line to work with a local vinca for faster iteration, but remember to comment it back
 # (and regenerate the pixi.lock) once you push the modified commit to the repo
 #vinca = { path = "../vinca", editable = true }

--- a/pixi.toml
+++ b/pixi.toml
@@ -27,7 +27,7 @@ git = "*"
 
 [feature.beta.pypi-dependencies]
 # This is tipically the latest commit on main branch
-vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "4630c72c9521c0234ef421cc3b0ce6244d9dff42" }
+vinca = { git = "https://github.com/RoboStack/vinca.git", rev = "cc79494f0217655dbd7c84cd17c18ed0b183c6d7" }
 # Uncomment this line to work with a local vinca for faster iteration, but remember to comment it back
 # (and regenerate the pixi.lock) once you push the modified commit to the repo
 #vinca = { path = "../vinca", editable = true }

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -1,0 +1,2 @@
+lanelet2_io:
+  build_number: 9

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -1,2 +1,4 @@
 lanelet2_io:
   build_number: 9
+ros_workspace:
+  build_number: 9

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Remainder for next full rebuild, the next build number should be 10
+# Reminder for next full rebuild, the next build number should be 10
 build_number: 7
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -5,7 +5,13 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
+# Remainder for next full rebuild, the next build number should be 10
 build_number: 7
+
+# Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml
+# should be used, not some build number obtained by checking the maximum
+# of all build numbers used in the target channel
+use_explicit_build_number: true
 
 mutex_package: ros2-distro-mutex 0.6.* humble_*
 

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Remainder for next full rebuild, the next build number should be 10
+# Reminder for next full rebuild, the next build number should be 10
 build_number: 5
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -5,7 +5,13 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
+# Remainder for next full rebuild, the next build number should be 10
 build_number: 5
+
+# Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml
+# should be used, not some build number obtained by checking the maximum
+# of all build numbers used in the target channel
+use_explicit_build_number: true
 
 mutex_package: ros2-distro-mutex 0.6.* humble_*
 

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Remainder for next full rebuild, the next build number should be 10
+# Reminder for next full rebuild, the next build number should be 10
 build_number: 7
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -5,7 +5,13 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
+# Remainder for next full rebuild, the next build number should be 10
 build_number: 7
+
+# Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml
+# should be used, not some build number obtained by checking the maximum
+# of all build numbers used in the target channel
+use_explicit_build_number: true
 
 mutex_package: ros2-distro-mutex 0.6.* humble_*
 

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -5,7 +5,13 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
+# Remainder for next full rebuild, the next build number should be 10
 build_number: 6
+
+# Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml
+# should be used, not some build number obtained by checking the maximum
+# of all build numbers used in the target channel
+use_explicit_build_number: true
 
 mutex_package: ros2-distro-mutex 0.6.* humble_*
 

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Remainder for next full rebuild, the next build number should be 10
+# Reminder for next full rebuild, the next build number should be 10
 build_number: 6
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -5,7 +5,13 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
+# Remainder for next full rebuild, the next build number should be 10
 build_number: 8
+
+# Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml
+# should be used, not some build number obtained by checking the maximum
+# of all build numbers used in the target channel
+use_explicit_build_number: true
 
 mutex_package: ros2-distro-mutex 0.6.* humble_*
 

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -5,7 +5,7 @@ conda_index:
   - robostack.yaml
   - packages-ignore.yaml
 
-# Remainder for next full rebuild, the next build number should be 10
+# Reminder for next full rebuild, the next build number should be 10
 build_number: 8
 
 # Specify that exactly the build_number used vinca*.yaml or pkg_additional_info.yaml


### PR DESCRIPTION
@wep21 noticed that after the build in https://github.com/RoboStack/ros-humble/pull/242, the build `ros-humble-lanelet2-io` package uses pugixml 1.15, while rviz uses pugixml 1.14 . This was a consequence of us not using the conda-forge complete pinning file due to https://github.com/prefix-dev/rattler-build/discussions/1285, and a recent pugixml update https://github.com/conda-forge/pugixml-feedstock/pull/27 .

As only the `lanelet2-io` package is affected, the best solution is to just rebuild this package with the correct pugixml version, to permit these I done the modification in vinca proposed in https://github.com/RoboStack/vinca/pull/67 .