### PR TITLE
Remove check for .yaml modification before recipe generated in testpr CI job and fix testpr job

### DIFF
--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -101,10 +101,14 @@ jobs:
       id: newrecipecheck
       shell: bash -l {0}
       run: |
+        if [ ! -d recipes ] || [ -z "$(ls -A recipes)" ]; then
+          echo "RECIPE_CREATED=0" >> $GITHUB_OUTPUT
+        else
+          echo "RECIPE_CREATED=1" >> $GITHUB_OUTPUT
+        fi
         # continue on error
         set +e
         test ! -d recipes
-        echo "::set-output name=RECIPE_CREATED::${?}"
     - name: Build recipes for linux-64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-64'

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -1,7 +1,6 @@
 on:
   pull_request:
-    paths:
-      - '*.yaml'
+  workflow_dispatch:
 
 env:
   ROS_VERSION: 2
@@ -73,7 +72,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for osx-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.OSX_YAML_CHANGED == 1 && matrix.platform == 'osx-64'
+      if: matrix.platform == 'osx-64'
       run: |
         cp vinca_osx.yaml vinca.yaml
         mkdir -p recipes

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -101,14 +101,12 @@ jobs:
       id: newrecipecheck
       shell: bash -l {0}
       run: |
+        set +e
         if [ ! -d recipes ] || [ -z "$(ls -A recipes)" ]; then
           echo "RECIPE_CREATED=0" >> $GITHUB_OUTPUT
         else
           echo "RECIPE_CREATED=1" >> $GITHUB_OUTPUT
         fi
-        # continue on error
-        set +e
-        test ! -d recipes
     - name: Build recipes for linux-64
       shell: bash -l {0}
       if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-64'

--- a/.github/workflows/testpr.yml
+++ b/.github/workflows/testpr.yml
@@ -55,26 +55,9 @@ jobs:
         rm -rf /c/Strawberry
         rm -rf "/c/Program Files (x86)/Windows Kits/10/Include/10.0.17763.0/"
 
-    - name: Check what files have changed
-      id: filecheck
-      shell: bash -l {0}
-      run: |
-        git fetch origin main
-        # continue on error
-        set +e
-        git diff --exit-code --name-only origin/main -- vinca_linux_64.yaml > /dev/null
-        echo "::set-output name=LINUX_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_linux_aarch64.yaml > /dev/null
-        echo "::set-output name=LINUX_AARCH_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_osx.yaml > /dev/null
-        echo "::set-output name=OSX_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_osx_arm64.yaml > /dev/null
-        echo "::set-output name=OSX_ARM_YAML_CHANGED::${?}"
-        git diff --exit-code --name-only origin/main -- vinca_win.yaml > /dev/null
-        echo "::set-output name=WIN_YAML_CHANGED::${?}"
     - name: Generate recipes for linux-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.LINUX_YAML_CHANGED == 1 && matrix.platform == 'linux-64'
+      if: matrix.platform == 'linux-64'
       run: |
         cp vinca_linux_64.yaml vinca.yaml
         mkdir -p recipes
@@ -82,7 +65,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for linux-aarch64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.LINUX_AARCH_YAML_CHANGED == 1 && matrix.platform == 'linux-aarch64'
+      if: matrix.platform == 'linux-aarch64'
       run: |
         cp vinca_linux_aarch64.yaml vinca.yaml
         mkdir -p recipes
@@ -98,7 +81,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for osx-arm64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.OSX_ARM_YAML_CHANGED == 1 && matrix.platform == 'osx-arm64'
+      if: matrix.platform == 'osx-arm64'
       run: |
         cp vinca_osx_arm64.yaml vinca.yaml
         mkdir -p recipes
@@ -106,7 +89,7 @@ jobs:
         ls -la recipes
     - name: Generate recipes for win-64
       shell: bash -l {0}
-      if: steps.filecheck.outputs.WIN_YAML_CHANGED == 1 && matrix.platform == 'win-64'
+      if: matrix.platform == 'win-64'
       run: |
         # Workaround for problem related to long paths
         echo "CONDA_BLD_PATH=C:\\bld\\" >> $GITHUB_ENV
@@ -125,31 +108,31 @@ jobs:
         echo "::set-output name=RECIPE_CREATED::${?}"
     - name: Build recipes for linux-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.LINUX_YAML_CHANGED == 1 && matrix.platform == 'linux-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
     - name: Build recipes for linux-aarch64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.LINUX_AARCH_YAML_CHANGED == 1 && matrix.platform == 'linux-aarch64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'linux-aarch64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform linux-aarch64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
     - name: Build recipes for osx-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.OSX_YAML_CHANGED == 1 && matrix.platform == 'osx-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
     - name: Build recipes for osx-arm64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.OSX_ARM_YAML_CHANGED == 1 && matrix.platform == 'osx-arm64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'osx-arm64'
       run: |
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
         env -i $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes --target-platform osx-arm64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
     - name: Build recipes for win-64
       shell: bash -l {0}
-      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && steps.filecheck.outputs.WIN_YAML_CHANGED == 1 && matrix.platform == 'win-64'
+      if: steps.newrecipecheck.outputs.RECIPE_CREATED == 1 && matrix.platform == 'win-64'
       run: |
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir additional_recipes --target-platform win-64 -m ./conda_build_config.yaml -c robostack-staging -c conda-forge --skip-existing
         $HOME/.pixi/bin/pixi run -e beta rattler-build build --recipe-dir recipes -m ./conda_build_config.yaml --target-platform win-64 -c robostack-staging -c conda-forge --skip-existing

--- a/patch/ros-humble-ffmpeg-encoder-decoder.patch
+++ b/patch/ros-humble-ffmpeg-encoder-decoder.patch
@@ -52,3 +52,23 @@ index da089e4..01e8eea 100644
        formats.push_back(*p);
      }
    }
+
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 7ba08db..b283bda 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -16,7 +16,13 @@
+ cmake_minimum_required(VERSION 3.16)
+ project(ffmpeg_encoder_decoder)
+ 
+-add_compile_options(-Wall -Wextra -Wpedantic -Werror)
++add_compile_options(-Wall -Wextra -Wpedantic)
++if(${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.24.0")
++  option(CMAKE_COMPILE_WARNING_AS_ERROR "Treat compiler warnings as errors." ON)
++  mark_as_advanced(CMAKE_COMPILE_WARNING_AS_ERROR)
++else()
++  add_compile_options(-Werror)
++endif()
+ 
+ # find dependencies
+ find_package(ament_cmake REQUIRED)


### PR DESCRIPTION
As we introduced several modifications in 2025, such as the use of rosdistro snapshot instead of always building the latest rosdistro, and the use of `pkg_additional_info.yaml` to bump the build number of packages that we want to rebuild, the check for `vinca_*.yaml` modification before running PR does not make a lot of sense. If a PR is not triggering the build of new packages, then the build step is super fast, and if instead a new recipe is triggered without us being aware of this, it is important that the PR CI catches the unintentional package generation.