### PR TITLE
Add build for ament_cmake_black

### DIFF
--- a/vinca_linux_64.yaml
+++ b/vinca_linux_64.yaml
@@ -215,6 +215,8 @@ packages_select_by_deps:
   
   - apriltag_detector
 
+  - ament_cmake_black
+
   # ----- end of package support -----
 
   # - rtabmap

--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -144,6 +144,8 @@ packages_select_by_deps:
   
   - apriltag_detector
 
+  - ament_cmake_black
+
   # Used to work, now needs fixes
   # - rtabmap
   # - webots-ros2

--- a/vinca_osx.yaml
+++ b/vinca_osx.yaml
@@ -158,5 +158,7 @@ packages_select_by_deps:
   
   - apriltag_detector
 
+  - ament_cmake_black
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_osx_arm64.yaml
+++ b/vinca_osx_arm64.yaml
@@ -148,5 +148,7 @@ packages_select_by_deps:
   
   - apriltag_detector
 
+  - ament_cmake_black
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml

--- a/vinca_win.yaml
+++ b/vinca_win.yaml
@@ -271,5 +271,7 @@ packages_select_by_deps:
   
   - apriltag_detector
 
+  - ament_cmake_black
+
 patch_dir: patch
 rosdistro_snapshot: rosdistro_snapshot.yaml


### PR DESCRIPTION
[ament_cmake_black](https://index.ros.org/p/ament_cmake_black)

The CMake API for ament_black to lint Python code using black.