### PR TITLE
Added nav2-bringup for aarch64 which was missing

### DIFF
--- a/vinca_linux_aarch64.yaml
+++ b/vinca_linux_aarch64.yaml
@@ -76,6 +76,7 @@ packages_select_by_deps:
   - vision-msgs-rviz-plugins
 
   - navigation2
+  - nav2_bringup
   - rviz2
   - behaviortree_cpp_v3
   - ament_cmake_catch2


### PR DESCRIPTION
While pulling in `nav2-bringup` to some pixi config I saw it's missing only for aarch64 so this adds it in Ref - https://robostack.github.io/humble.html 