### PR TITLE
CI Hotfix when none packages where built

### DIFF
--- a/.scripts/build_unix.sh
+++ b/.scripts/build_unix.sh
@@ -48,4 +48,10 @@ for recipe in ${CURRENT_RECIPES[@]}; do
 
 done
 
-pixi run upload ${CONDA_BLD_PATH}/${target}*/*.conda --force
+# Check if it build something, this is a hotfix for the skips inside additional_recipes 
+if compgen -G "${CONDA_BLD_PATH}/${target}*/*.conda" > /dev/null; then
+    pixi run upload "${CONDA_BLD_PATH}/${target}"*/*.conda --force
+else
+    echo "Warning: No .conda files found in ${CONDA_BLD_PATH}/${target}"
+    echo "This might be due to all the packages being skipped"
+fi


### PR DESCRIPTION
Currently, the CI is failing due to the additional recipes added for emscripten, which are skipped by rattler-build, resulting in the CI failing due to having an empty output folder.

This pr is a hotfix to check first if anything was built before attempting to upload it, this will effectively fix https://github.com/RoboStack/ros-humble/actions/runs/14767448589 

A better approach would be to check in vinca generate_gha to implement a parse skip, in https://github.com/RoboStack/vinca/blob/9eb0b36b3cb673f6ab0789dd22f06668ccae5fd3/vinca/generate_gha.py#L197 , but I couldn't find the whole list of possible names for the platforms that rattler-build takes


