### PR TITLE
Add ign-ros2-control and gz-ros2-control on non-Windows platforms

### DIFF
--- a/robostack.yaml
+++ b/robostack.yaml
@@ -166,8 +166,6 @@ ignition-gazebo3:
 ignition-gazebo5:
   robostack: [libignition-gazebo5]
 ignition-gazebo6:
-  robostack: [libignition-gazebo6]
-ignition-gazebo6:
   robostack:
     linux: [libignition-gazebo6, libgl-devel]
     osx: [libignition-gazebo6]

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -167,6 +167,11 @@ ignition-gazebo5:
   robostack: [libignition-gazebo5]
 ignition-gazebo6:
   robostack: [libignition-gazebo6]
+ignition-gazebo6:
+  robostack:
+    linux: [libignition-gazebo6, libgl-devel]
+    osx: [libignition-gazebo6]
+    win64: [libignition-gazebo6]
 ignition-gui5:
   robostack: [libignition-gui5]
 ignition-math6:

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -390,6 +390,8 @@ packages_select_by_deps:
       # look to Jazzy or Kilted if you are interested in it, see
       # https://github.com/RoboStack/ros-humble/pull/320
       - ros_gz
+      - ign_ros2_control
+      - gz_ros2_control
       # Some nominmax/max macro problems on octomap-server, easy to fix with a bit of time
       - grid_map
       # error C2338: static_assert failed: 'N4971 [rand.util.seedseq]/7 requires the value type of the iterator 


### PR DESCRIPTION
I just found out we ere missing those in https://github.com/Sooner-Rover-Team/auto_ros2/pull/119/files#r2282899688, but it should be easy to compile them.