### PR TITLE
added ur_simulation_gz

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -236,6 +236,7 @@ packages_select_by_deps:
       - apriltag            # AprilRobotics
       - ur_robot_driver     # Universal Robots
       - ur_calibration      # Universal Robots, requested in https://github.com/RoboStack/ros-humble/issues/217
+      - ur_simulation_gz
       - stubborn_buddies    # Open RMF
       - ament_cmake_catch2  # Open RMF
       - ament_cmake_vendor_package # Requested in https://github.com/RoboStack/ros-humble/pull/210

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -236,7 +236,6 @@ packages_select_by_deps:
       - apriltag            # AprilRobotics
       - ur_robot_driver     # Universal Robots
       - ur_calibration      # Universal Robots, requested in https://github.com/RoboStack/ros-humble/issues/217
-      - ur_simulation_gz
       - stubborn_buddies    # Open RMF
       - ament_cmake_catch2  # Open RMF
       - ament_cmake_vendor_package # Requested in https://github.com/RoboStack/ros-humble/pull/210
@@ -365,6 +364,8 @@ packages_select_by_deps:
       # Building on macOS it should be doable, but currently it failed due to https://github.com/RoboStack/ros-humble/pull/343#issuecomment-3253547513 
       - ign_ros2_control
       - gz_ros2_control
+      # ur manipulator simulation
+      - ur_simulation_gz
 
   # These packages are currently not build on Windows, but they may with some work
   - if: not wasm32 and not win


### PR DESCRIPTION
Only caveat: if one using this package, the gz related env variable should be properly set
```bash
export IGN_GAZEBO_SYSTEM_PLUGIN_PATH=$CONDA_PREFIX/lib
export LD_LIBRARY_PATH=$CONDA_PREFIX/lib:$LD_LIBRARY_PATH
```

before doing `ros2 launch ur_simulation_gz ur_sim_control.launch.py`

Not sure if (and how) I should automate that to be frank. Maybe patching the python launch script ? Let me know, thanks !

