### PR TITLE
build `gz-ros2-control` both on Linux and macOS

### DIFF
--- a/patch/ros-humble-gz-ros2-control.patch
+++ b/patch/ros-humble-gz-ros2-control.patch
@@ -1,0 +1,28 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5e4ce57..b2f3a8d 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -1,6 +1,23 @@
+ cmake_minimum_required(VERSION 3.5)
+ project(gz_ros2_control)
+ 
++# Fix for macOS case sensitivity issue with TinyXML2 targets
++# ignition-gui6 from conda-forge expects TINYXML2::TINYXML2 but macOS provides tinyxml2::tinyxml2
++# We need to create the uppercase target before any ignition packages are loaded
++find_package(TinyXML2 REQUIRED)
++if(TARGET tinyxml2::tinyxml2 AND NOT TARGET TINYXML2::TINYXML2)
++  # Create an INTERFACE IMPORTED target with the expected name
++  add_library(TINYXML2::TINYXML2 INTERFACE IMPORTED GLOBAL)
++  # Link it to the actual lowercase target
++  set_property(TARGET TINYXML2::TINYXML2 PROPERTY INTERFACE_LINK_LIBRARIES tinyxml2::tinyxml2)
++  # Copy include directories if they exist
++  get_target_property(tinyxml2_includes tinyxml2::tinyxml2 INTERFACE_INCLUDE_DIRECTORIES)
++  if(tinyxml2_includes)
++    set_property(TARGET TINYXML2::TINYXML2 PROPERTY INTERFACE_INCLUDE_DIRECTORIES ${tinyxml2_includes})
++  endif()
++  message(STATUS "Created TINYXML2::TINYXML2 compatibility target for ignition packages")
++endif()
++
+ # Default to C++14
+ if(NOT CMAKE_CXX_STANDARD)
+   set(CMAKE_CXX_STANDARD 14)

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -310,9 +310,7 @@ packages_select_by_deps:
       - vector_pursuit_controller
       # Requested in https://github.com/RoboStack/ros-humble/issues/345
       - topic_based_ros2_control
-      - ign_ros2_control
-      - gz_ros2_control
-      - ur_simulation_gz
+
 
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
@@ -429,4 +427,8 @@ packages_select_by_deps:
       - spacenav
       # unresolved external symbol "public: static struct QMetaObject const rviz_default_plugins::displays::MarkerNamespace::staticMetaObject"
       - vision-msgs-rviz-plugins
+      
+      - ign_ros2_control
+      - gz_ros2_control
+      - ur_simulation_gz
 

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -310,11 +310,8 @@ packages_select_by_deps:
       - vector_pursuit_controller
       # Requested in https://github.com/RoboStack/ros-humble/issues/345
       - topic_based_ros2_control
-
-      # Building on macOS it should be doable, but currently it failed due to https://github.com/RoboStack/ros-humble/pull/343#issuecomment-3253547513 
       - ign_ros2_control
       - gz_ros2_control
-      # ur manipulator simulation
       - ur_simulation_gz
 
   # These packages are only built on Linux as they depend on Linux-specific API

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -311,6 +311,12 @@ packages_select_by_deps:
       # Requested in https://github.com/RoboStack/ros-humble/issues/345
       - topic_based_ros2_control
 
+      # Building on macOS it should be doable, but currently it failed due to https://github.com/RoboStack/ros-humble/pull/343#issuecomment-3253547513 
+      - ign_ros2_control
+      - gz_ros2_control
+      # ur manipulator simulation
+      - ur_simulation_gz
+
   # These packages are only built on Linux as they depend on Linux-specific API
   - if: linux
     then:
@@ -363,11 +369,7 @@ packages_select_by_deps:
       # Franka robots suppot
       # See https://github.com/RoboStack/ros-humble/pull/338#issuecomment-3146453142 for macos and Windows errors
       - franka_ros2
-      # Building on macOS it should be doable, but currently it failed due to https://github.com/RoboStack/ros-humble/pull/343#issuecomment-3253547513 
-      - ign_ros2_control
-      - gz_ros2_control
-      # ur manipulator simulation
-      - ur_simulation_gz
+
 
   # These packages are currently not build on Windows, but they may with some work
   - if: not wasm32 and not win


### PR DESCRIPTION
This deals with https://github.com/RoboStack/ros-humble/pull/343#issuecomment-3271126846 and extend https://github.com/RoboStack/ros-humble/pull/344 to macOS