### PR TITLE
Add mocap4r2_msgs

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -145,6 +145,7 @@ packages_select_by_deps:
   # all the other platforms (so the majority)
   - if: not wasm32
     then:
+      - mocap4r2_msgs
       - ros2-controllers
       - diff-drive-controller
       - ros_workspace


### PR DESCRIPTION
I'm working with [aerostack2](https://aerostack2.github.io) to make it cross-platform (slowly). This dependency is a blocker for one of the AS2 packages.

The mocap4r2_msgs is a simple package that I was able to build in non-wasm environments by generating the recipe and building it with rattler-builder.

```
pixi run vinca -d . -s humble --platform <platform> -p mocap4r2_msgs
```

And then

```
pixi run rattler-build build \
  --recipe ./recipes/ros-humble-<package-name>/recipe.yaml \
  -m ./conda_build_config.yaml \
  -c https://repo.prefix.dev/conda-forge \
  -c robostack-staging \
  -c file://$PWD/output \
  --target-platform <platform>
```