### PR TITLE
Enable as2_msgs

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -431,6 +431,7 @@ packages_select_by_deps:
       - vision-msgs-rviz-plugins
       # aerostack2
       - as2_cli
+      - as2_msgs
 
       - ign_ros2_control
       - gz_ros2_control


### PR DESCRIPTION
Enabling Aerostack package `as2_msgs`. For the time being, only enabled in non-wasm and non-win envs.