### PR TITLE
Added `ros-humble-mavros` and `ros-humble-mavlink` in Linux

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -335,6 +335,10 @@ packages_select_by_deps:
       # Require Linux-specific joystick interfaces
       - joy_linux
 
+      # mavros and mavlink (currently Linux only)
+      - mavlink
+      - mavros
+
   # These packages are currently only build on Linux,
   # as trying to build them in the past on macos or Windows resulted in errors,
   # but probably they can work on all platform with some work


### PR DESCRIPTION
Didn't add other platforms due to upstream limitation