### PR TITLE
add ros2-control-cmake

### DIFF
--- a/rosdistro_snapshot.yaml
+++ b/rosdistro_snapshot.yaml
@@ -5507,6 +5507,10 @@ ros2_control:
   tag: release/humble/ros2_control/2.51.0-1
   url: https://github.com/ros2-gbp/ros2_control-release.git
   version: 2.51.0
+ros2_control_cmake:
+  tag: release/humble/ros2_control_cmake/0.2.1-1
+  url: https://github.com/ros2-gbp/ros2_control_cmake-release.git
+  version: 0.2.1
 ros2_control_test_assets:
   tag: release/humble/ros2_control_test_assets/2.51.0-1
   url: https://github.com/ros2-gbp/ros2_control-release.git

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -148,6 +148,7 @@ packages_select_by_deps:
       - mocap4r2_msgs
       - ros2-controllers
       - pal_statistics
+      - ros2-control-cmake
       - diff-drive-controller
       - ros_workspace
       - ros_core


### PR DESCRIPTION
since this package is new, I manually added it to the snapshot. Tested locally with `pixi run build`, seems good!

```
 │ │
 │ ╰─────────────────── (took 0 seconds)
 │
 ╰─────────────────── (took 8 seconds)
 Collecting tests from '/home/peter/.cache/rattler/cache/pkgs/ros-humble-ros2-control-cmake-0.2.1-np126py311hbc2a38a_13'
 ✔ all tests passed!

 ╭─ Build summary
 │
 │ ╭─ Build summary for recipe: ros-humble-ros2-control-cmake-0.2.1-np126py311hbc2a38a_13
 │ │ Artifact: /home/peter/Documents/ros-humble/output/linux-64/ros-humble-ros2-control-cmake-0.2.1-np126py311hbc2a38a_13.conda (27.11 KiB)
 │ │ Variant configuration (hash: np126py311hbc2a38a_13):
```