### PR TITLE
add radar_msgs

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -297,6 +297,7 @@ packages_select_by_deps:
       - behaviortree_cpp
       - py-binding-tools
       - nmea_msgs
+      - radar_msgs
       - rtcm_msgs
       # cascade lifecycle packages
       - cascade-lifecycle-msgs


### PR DESCRIPTION
This PR adds `radar_msgs`.
Since all other `*_msgs` are excluding `wasm32` I expect adding it there as well is fine. Also, I added it semi-alphabetically where it seemed to fit best. Please let me know if I should move it somewhere else :smiley: 