### PR TITLE
Add mavlink/mavros support for macOS (osx-arm64)

### DIFF
--- a/patch/ros-humble-mavlink.osx.patch
+++ b/patch/ros-humble-mavlink.osx.patch
@@ -1,0 +1,20 @@
+diff --git a/pymavlink/generator/CPP11/include_v2.0/msgmap.hpp b/pymavlink/generator/CPP11/include_v2.0/msgmap.hpp
+index a3956aa2..2abe2a5e 100644
+--- a/pymavlink/generator/CPP11/include_v2.0/msgmap.hpp
++++ b/pymavlink/generator/CPP11/include_v2.0/msgmap.hpp
+@@ -4,7 +4,14 @@
+ #include <algorithm>
+ #ifdef FREEBSD
+ #include <sys/endian.h>
+-#elif __APPLE__
++#elif defined(__APPLE__)
++#include <libkern/OSByteOrder.h>
++#define htole16(x) OSSwapHostToLittleInt16(x)
++#define htole32(x) OSSwapHostToLittleInt32(x)
++#define htole64(x) OSSwapHostToLittleInt64(x)
++#define le16toh(x) OSSwapLittleToHostInt16(x)
++#define le32toh(x) OSSwapLittleToHostInt32(x)
++#define le64toh(x) OSSwapLittleToHostInt64(x)
+ #include <machine/endian.h>
+ #else
+ #include <endian.h>

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -151,5 +151,11 @@ rosidl_generator_cpp:
   build_number: 14
 rosidl_runtime_cpp:
   build_number: 14
+mavlink:
+  build_number: 14
+libmavconn:
+  build_number: 14
 mavros:
+  build_number: 14
+mavros_msgs:
   build_number: 14

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -341,10 +341,6 @@ packages_select_by_deps:
       # Require Linux-specific joystick interfaces
       - joy_linux
 
-      # mavros and mavlink (currently Linux only)
-      - mavlink
-      - mavros
-
   # These packages are currently only build on Linux,
   # as trying to build them in the past on macos or Windows resulted in errors,
   # but probably they can work on all platform with some work
@@ -445,3 +441,6 @@ packages_select_by_deps:
       - ign_ros2_control
       - gz_ros2_control
       - ur_simulation_gz
+      # mavros and mavlink (enabled on macOS for testing)
+      - mavlink
+      - mavros


### PR DESCRIPTION
- Add ros-humble-mavlink.osx.patch to fix macOS endian function compatibility
- Move mavlink/mavros from Linux-only section to not wasm32 and not win section in vinca.yaml      
- Add build_number entries to trigger rebuilds                                                                                                                                                                                                                                                          
                                                                                                                                                                                                            
  Details                                                                                                                                                                                        
- macOS's <machine/endian.h> doesn't define the htole16, htole32, htole64, le16toh, le32toh, le64toh functions that Linux provides via <endian.h>. The patch includes <libkern/OSByteOrder.h> and defines macros mapping to the macOS equivalents (OSSwapHostToLittleInt* and OSSwapLittleToHostInt*).       
  
Tested:                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                 
  - Built mavlink on osx-arm64                                                                                                                                                                              
  - Built libmavconn on osx-arm64                                                                                                                                                                           
  - Built mavros-msgs on osx-arm64                                                                                                                                                                          
  - Built mavros on osx-arm64   