### PR TITLE
Add mavros_extras support for Linux and macOS

### DIFF
--- a/patch/ros-humble-mavros-extras.patch
+++ b/patch/ros-humble-mavros-extras.patch
@@ -1,0 +1,51 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 5cb1fae47..cd5eee700 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -34,11 +34,10 @@ find_package(eigen3_cmake_module REQUIRED)
+ find_package(Eigen3 REQUIRED)
+ find_package(yaml_cpp_vendor REQUIRED)
+
+-## Find GeographicLib
+-# Append to CMAKE_MODULE_PATH since debian/ubuntu installs
+-# FindGeographicLib.cmake in a nonstand location
+-set(CMAKE_MODULE_PATH "${CMAKE_MODULE_PATH};/usr/share/cmake/geographiclib")
+-find_package(GeographicLib REQUIRED)
++# Find GeographicLib
++# Use CONFIG mode to find GeographicLib from conda package
++# (libmavconn already sets CMAKE_MODULE_PATH for CheckGeographicLibDatasets)
++find_package(GeographicLib REQUIRED CONFIG)
+
+ find_package(angles REQUIRED)
+ find_package(eigen_stl_containers REQUIRED)
+@@ -156,6 +155,8 @@ ament_target_dependencies(mavros_extras_plugins
+   yaml_cpp_vendor
+ )
+ pluginlib_export_plugin_description_file(mavros mavros_plugins.xml)
++# Link GeographicLib - not handled by ament_target_dependencies
++target_link_libraries(mavros_extras_plugins ${GeographicLib_LIBRARIES})
+
+ add_library(mavros_extras SHARED
+   # [[[cog:
+diff --git a/src/plugins/fake_gps.cpp b/src/plugins/fake_gps.cpp
+index 2a5b99fb4..451e8832c 100644
+--- a/src/plugins/fake_gps.cpp
++++ b/src/plugins/fake_gps.cpp
+@@ -401,7 +401,7 @@ private:
+   /* -*- callbacks -*- */
+   void mocap_tf_cb(const geometry_msgs::msg::TransformStamped::SharedPtr trans)
+   {
+-    Eigen::Affine3d pos_enu; tf2::fromMsg(trans->transform, pos_enu);
++    Eigen::Affine3d pos_enu(tf2::transformToEigen(trans->transform));
+
+     send_fake_gps(
+       trans->header.stamp,
+@@ -439,7 +439,7 @@ private:
+
+   void transform_cb(const geometry_msgs::msg::TransformStamped & trans)
+   {
+-    Eigen::Affine3d pos_enu; tf2::fromMsg(trans.transform, pos_enu);
++    Eigen::Affine3d pos_enu(tf2::transformToEigen(trans.transform));
+
+     send_fake_gps(
+       trans.header.stamp,

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -159,3 +159,5 @@ mavros:
   build_number: 14
 mavros_msgs:
   build_number: 14
+mavros_extras:
+  build_number: 14

--- a/vinca.yaml
+++ b/vinca.yaml
@@ -444,3 +444,4 @@ packages_select_by_deps:
       # mavros and mavlink (enabled on macOS for testing)
       - mavlink
       - mavros
+      - mavros_extras


### PR DESCRIPTION
## Summary
- Adds cross-platform patch (`ros-humble-mavros-extras.patch`) enabling `mavros_extras` to build on Linux and macOS
- Enables the package in `vinca.yaml` under the `not wasm32 and not win` condition

## Changes
| File | Description |
|------|-------------|
| `patch/ros-humble-mavros-extras.patch` | Fixes GeographicLib discovery (CONFIG mode), library linking, and tf2 API compatibility |
| `vinca.yaml` | Adds `mavros_extras` to the package list |
| `pkg_additional_info.yaml` | Adds build_number entry for `mavros_extras` |

## Platforms
- ✅ linux-64
- ✅ linux-aarch64
- ✅ osx-64
- ✅ osx-arm64