### PR TITLE
add robotique 2f 85 gripper description and controllers package

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -445,3 +445,7 @@ packages_select_by_deps:
       - mavlink
       - mavros
       - mavros_extras
+
+      # robotique grippers
+      - robotiq_description
+      - robotiq_controllers


### PR DESCRIPTION
Allows one to visualize robotiq 2-finger gripper. Tested in both linux 64 and osx-arm64.