### PR TITLE
fix: update instructions for invoking pixi run commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ Working notes for future coding agents in a RoboStack repo. Replace $DISTRO with
 
 ```bash
 # single package (preferred for debugging)
-pixi run build-one --package ros-$DISTRO-<pkg>
+pixi run build-one ros-$DISTRO-<pkg>
 
 # broad pass when needed
 pixi run build_continue_on_failure
@@ -91,7 +91,7 @@ bash -x conda_build.sh 2>&1 | less
 ### 7. Rebuild package
 
 ```bash
-pixi run build-one --package ros-$DISTRO-<pkg>
+pixi run build-one ros-$DISTRO-<pkg>
 ```
 
 ## Create a patch from build-directory edits

--- a/pixi.toml
+++ b/pixi.toml
@@ -42,7 +42,7 @@ check-patches-emscripten = { cmd = "python check_patches_clean_apply.py", depend
 [tasks.build]
 cmd = "rattler-build build --recipe-dir ./recipes -m ./conda_build_config.yaml -c https://repo.prefix.dev/conda-forge -c robostack-staging --skip-existing"
 depends-on = ["generate-recipes"]
-description = "Build all packages, from the ./recipes dir. This will skip already existing packages, so it can be used to build only a subset of packages by first removing the recipes of the packages you want to rebuild (see `pixi remove-recipes`)."
+description = "Build all packages, from the ./recipes dir. This will skip already existing packages, so it can be used to build only a subset of packages by first removing the recipes of the packages you want to rebuild (see `pixi run remove-recipes`)."
 
 [tasks.remove-recipes]
 cmd = "rm -rf recipes_only_patch; rm -rf recipes; mkdir recipes"
@@ -51,7 +51,7 @@ description = "Remove all generated recipes, before regenerating them."
 [tasks.build-one]
 cmd = "cp ./patch/{{ PACKAGE }}.*patch ./recipes/{{ PACKAGE }}/patch/; rattler-build build --recipe ./recipes/{{ PACKAGE }}/recipe.yaml -m ./conda_build_config.yaml -c https://repo.prefix.dev/conda-forge -c robostack-staging"
 args = [{ arg = "PACKAGE", default = "ros-humble-ros-workspace" }]
-description = "Build a single package, from the ./recipes dir. Add the `ros-humble-` prefix to the package name, e.g. `pixi build-one --package ros-humble-ros-workspace`"
+description = "Build a single package, from the ./recipes dir. Add the `ros-humble-` prefix to the package name, e.g. `pixi run build-one ros-humble-ros-workspace`"
 
 [tasks.build-emscripten]
   cmd = [


### PR DESCRIPTION
This PR fixes the document on how to build one package, neither `--package` or `-- --package` worked for me, but just `pixi run build-one ros-humble-rsl` actually worked:

<pre>…<font color="#0AB9DC"><b>/home/esteve/Projects/Bonsai/RoboStack/ros-humble</b></font> on <font color="#9841BB"><b> main</b></font> via <font color="#F5C211"><b>🐍 v3.14.4 </b></font>via <font color="#F5C211"><b>🧚 v0.67.2 </b></font>
<font color="#C01C28"><b>❯</b></font> pixi <font color="#0AB9DC">run</font> <font color="#0AB9DC">build-one</font> <font color="#0AB9DC">--package</font> <font color="#0AB9DC">ros-humble-rsl</font>
Error:   <font color="#C01C28">×</font> task &apos;build-one&apos; received more arguments than expected
<font color="#0AB9DC">  help: </font>use `--` to separate task arguments from extra passthrough arguments


…<font color="#0AB9DC"><b>/home/esteve/Projects/Bonsai/RoboStack/ros-humble</b></font> on <font color="#9841BB"><b> main</b></font> via <font color="#F5C211"><b>🐍 v3.14.4 </b></font>via <font color="#F5C211"><b>🧚 v0.67.2 </b></font>
<font color="#C01C28"><b>❯</b></font> pixi <font color="#0AB9DC">run</font> <font color="#0AB9DC">build-one</font> <font color="#0AB9DC">--</font> <font color="#0AB9DC">--package</font> <font color="#0AB9DC">ros-humble-rsl</font>
✨ <b>Pixi task (</b><font color="#2EC27E"><b>build-one</b></font><b>): </b><font color="#1E78E4"><b>cp ./patch/ros-humble-ros-workspace.*patch ./recipes/ros-humble-ros-workspace/patch/; rattler-build build --recipe ./recipes/ros-humble-ros-workspace/recipe.yaml -m ./conda_build_config.yaml -c https://repo.prefix.dev/conda-forge -c robostack-staging</b></font> <font color="#1E78E4">--package ros-humble-rsl</font><font color="#F5C211">: (Build a single package, from the ./recipes dir. Add the `ros-humble-` prefix to the package name, e.g. `pixi build-one ros-humble-ros-workspace`)</font>
cp: could not copy patch/ros-humble-ros-workspace.patch to ./recipes/ros-humble-ros-workspace/patch/: No such file or directory (os error 2)
<font color="#C01C28"><b>error:</b></font> unexpected argument &apos;<font color="#F5C211">--package</font>&apos; found

  <font color="#2EC27E">tip:</font> a similar argument exists: &apos;<font color="#2EC27E">--package-format</font>&apos;

<u style="text-decoration-style:solid"><b>Usage:</b></u> <b>rattler-build build</b> <b>--recipe</b> &lt;RECIPES&gt; <b>--variant-config</b> &lt;VARIANT_CONFIG&gt; <b>--channel</b> &lt;CHANNELS&gt; <b>--package-format</b> &lt;PACKAGE_FORMAT&gt;

For more information, try &apos;<b>--help</b>&apos;.

…<font color="#0AB9DC"><b>/home/esteve/Projects/Bonsai/RoboStack/ros-humble</b></font> on <font color="#9841BB"><b> main</b></font> via <font color="#F5C211"><b>🐍 v3.14.4 </b></font>via <font color="#F5C211"><b>🧚 v0.67.2 </b></font>
<font color="#C01C28"><b>❯</b></font> 

</pre>