### PR TITLE
fix: ignore chrony system service

### DIFF
--- a/packages-ignore.yaml
+++ b/packages-ignore.yaml
@@ -2,7 +2,10 @@
 rti-connext-dds-5.3.1:
   conda-forge: []
 
-# System service/runtime package used by TurtleBot 4 setup.
+# System service/runtime packages used by TurtleBot 4 setup.
+chrony:
+  robostack: []
+
 network-manager:
   robostack: []
 

--- a/robostack.yaml
+++ b/robostack.yaml
@@ -45,11 +45,6 @@ ca-certificates:
   robostack: [ca-certificates]
 cargo:
   robostack: [rust]
-chrony:
-  robostack:
-    linux: [chrony]
-    osx: [chrony]
-    win64: []
 clang-format:
   robostack: [clang-format]
 clang-tidy:


### PR DESCRIPTION
`turtlebot4_setup` is the only package in RoboStack that declares `chrony` as a dependency, but it does not even configure it or use `chronyc`. The `turtlebot4_setup` package just copies its `chrony.conf` file to `chrony`. This is the same scenario as with `network-manager`