### PR TITLE
fix: zsh autocompletion

### DIFF
--- a/patch/ros-humble-ros2cli.patch
+++ b/patch/ros-humble-ros2cli.patch
@@ -12,11 +12,23 @@ index a5f2d67..ab9f656 100644
 +if type register-python-argcomplete > /dev/null 2>&1; then
    eval "$(register-python-argcomplete ros2)"
  fi
+diff --git a/ros2cli/completion/ros2-argcomplete.zsh b/ros2cli/completion/ros2-argcomplete.zsh
+index f83d64d..94b754b 100644
+--- a/ros2cli/completion/ros2-argcomplete.zsh
++++ b/ros2cli/completion/ros2-argcomplete.zsh
+@@ -18,6 +18,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __ros2cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__ros2cli_completion_dir/ros2-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"
+ # Cleanup
+ unset __ros2cli_completion_dir
 diff --git a/ros2cli/setup.py b/ros2cli/setup.py
-index 232c5bc..d774f33 100644
+index 956b708..b9a82cc 100644
 --- a/ros2cli/setup.py
 +++ b/ros2cli/setup.py
-@@ -20,6 +20,14 @@ setup(
+@@ -23,6 +23,14 @@ setup(
              'completion/ros2-argcomplete.bash',
              'completion/ros2-argcomplete.zsh'
          ]),

--- a/patch/ros-humble-rosidl.patch
+++ b/patch/ros-humble-rosidl.patch
@@ -12,15 +12,27 @@ index 0262ec2..c3e8606 100644
 +if type register-python-argcomplete > /dev/null 2>&1; then
    eval "$(register-python-argcomplete rosidl)"
  fi
+diff --git a/rosidl_cli/completion/rosidl-argcomplete.zsh b/rosidl_cli/completion/rosidl-argcomplete.zsh
+index 9a86dbd..c4a4253 100644
+--- a/rosidl_cli/completion/rosidl-argcomplete.zsh
++++ b/rosidl_cli/completion/rosidl-argcomplete.zsh
+@@ -18,6 +18,6 @@ autoload -U +X bashcompinit && bashcompinit
+ # Get this scripts directory
+ __rosidl_cli_completion_dir=${0:a:h}
+ # Just source the bash version, it works in zsh too
+-source "$__rosidl_cli_completion_dir/rosidl-argcomplete.bash"
++source "$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"
+ # Cleanup
+ unset __rosidl_cli_completion_dir
 diff --git a/rosidl_cli/setup.py b/rosidl_cli/setup.py
-index bacc9e8..b4fd32c 100644
+index dd12abb..4cd1fcf 100644
 --- a/rosidl_cli/setup.py
 +++ b/rosidl_cli/setup.py
-@@ -20,6 +20,14 @@ setup(
+@@ -23,6 +23,14 @@ setup(
              'completion/rosidl-argcomplete.bash',
              'completion/rosidl-argcomplete.zsh'
          ]),
-+        
++
 +        # [pixi] install autocompletion scripts
 +        ('share/bash-completion/completions', [
 +            'completion/rosidl-argcomplete.bash',

--- a/pkg_additional_info.yaml
+++ b/pkg_additional_info.yaml
@@ -177,3 +177,7 @@ rosidl_cmake:
   build_number: 19
 ros2pkg:
   build_number: 19
+rosidl_cli:
+  build_number: 19
+ros2cli:
+  build_number: 19

--- a/tests/ros-humble-ros2cli.yaml
+++ b/tests/ros-humble-ros2cli.yaml
@@ -5,3 +5,4 @@ tests:
       then:
         - test -f ${PREFIX}/share/bash-completion/completions/ros2-argcomplete.bash
         - test -f ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh
+        - grep -q 'source "\$CONDA_PREFIX/share/bash-completion/completions/ros2-argcomplete.bash"' ${PREFIX}/share/zsh/site-functions/ros2-argcomplete.zsh

--- a/tests/ros-humble-rosidl.yaml
+++ b/tests/ros-humble-rosidl.yaml
@@ -5,3 +5,4 @@ tests:
       then:
         - test -f ${PREFIX}/share/bash-completion/completions/rosidl-argcomplete.bash
         - test -f ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh
+        - grep -q 'source "\$CONDA_PREFIX/share/bash-completion/completions/rosidl-argcomplete.bash"' ${PREFIX}/share/zsh/site-functions/rosidl-argcomplete.zsh


### PR DESCRIPTION
The ZSH autocompletion was depending on the bash autocompletion so this PR patches that the zsh script looks in the right location for the bash completions