### PR TITLE
Add zed_description package 

### DIFF
--- a/vinca.yaml
+++ b/vinca.yaml
@@ -344,6 +344,8 @@ packages_select_by_deps:
       - ptz_action_server_msgs
       # Requested in https://github.com/RoboStack/ros-humble/issues/394
       - zed-msgs
+      # Requested in https://github.com/RoboStack/ros-humble/issues/421
+      - zed_description
 
       # Requested in https://github.com/RoboStack/ros-humble/issues/345
       - topic_based_ros2_control


### PR DESCRIPTION
Add `zed_description` to the package seeds for Linux, macOS, and Windows (including the supported ARM targets)

LLM assisted validation:
- Generated the recipe using the locked Vinca environment (`pixi run vinca -m`).
- Built `ros-humble-zed-description` 0.1.5 on linux-64 with `pixi run build-one ros-humble-zed-description`.
- Installed the resulting Conda artifact and runtime dependencies into a fresh Pixi environment.
- Verified ROS package discovery and expanded all 15 supported camera models with Xacro; checked joint link references and the existence of every referenced mesh.